### PR TITLE
uses the backup array for RPM %config files

### DIFF
--- a/makepkg.sh
+++ b/makepkg.sh
@@ -45,7 +45,7 @@ declare -r startdir="$PWD"
 
 packaging_options=('strip')
 other_options=('ccache' 'distcc' 'buildflags' 'makeflags')
-splitpkg_overrides=('pkgdesc' 'arch' 'url' 'license' 'groups' 'backup' 'depends'
+splitpkg_overrides=('pkgdesc' 'arch' 'url' 'license' 'groups' 'depends'
                     'optdepends' 'provides' 'conflicts' 'replaces' 'backup'
                     'options' 'install' 'changelog')
 readonly -a packaging_options other_options splitpkg_overrides

--- a/makepkg.sh
+++ b/makepkg.sh
@@ -45,7 +45,7 @@ declare -r startdir="$PWD"
 
 packaging_options=('strip')
 other_options=('ccache' 'distcc' 'buildflags' 'makeflags')
-splitpkg_overrides=('pkgdesc' 'arch' 'url' 'license' 'groups' 'depends'
+splitpkg_overrides=('pkgdesc' 'arch' 'url' 'license' 'groups' 'backup' 'depends'
                     'optdepends' 'provides' 'conflicts' 'replaces' 'backup'
                     'options' 'install' 'changelog')
 readonly -a packaging_options other_options splitpkg_overrides
@@ -2269,6 +2269,9 @@ run_fpm() {
 	cmd="$cmd $epoch_param"
 	cmd="$cmd -C \"$pkgdir\""         # chdir here for contents
 	cmd="$cmd $after_install_param"
+	for item in "${backup[@]}"; do
+		cmd="$cmd --config-files \"$item\""
+	done
 	for item in "${depends[@]}"; do
 		cmd="$cmd -d \"$item\""
 	done


### PR DESCRIPTION
## References
- [backup variable in PKGBUILD](https://wiki.archlinux.org/index.php/PKGBUILD#backup)
- [RPM %config Files](https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s05s03.html)
- [The %config Directive in RPM Files (Maximum RPM)](http://www.rpm.org/max-rpm/s1-rpm-inside-files-list-directives.html)
- [RPM erase and config files](http://www.rpm.org/max-rpm/s1-rpm-erase-and-config-files.html)
- [Display the Package's List of Configuration Files](http://www.rpm.org/max-rpm/s1-rpm-query-parts.html#S3-RPM-QUERY-C-OPTION)

FPM handles config files with the `--config-files` arg, which is specified multiple times:

```
--config-files CONFIG_FILES   Mark a file in the package as being a config file. This uses 'conffiles' in debs and %config in rpm. If you have multiple files to mark as configuration files, specify this flag multiple times.  If argument is directory all files inside it will be recursively marked as config files.
```

List of Config Files in v2.8.1 (created with this feature branch):

```
(venv) [root@localhost makepkg]# rpm -qpc /root/soltra-edge-2.8.1-5.x86_64.rpm
warning: /root/soltra-edge-2.8.1-5.x86_64.rpm: Header V4 RSA/SHA1 Signature, key ID eb9efdda: NOKEY
/etc/httpd/conf.d/localtaxii.vhost
/etc/httpd/conf.d/repo.conf
/etc/httpd/conf.d/repo.vhost
/etc/httpd/conf.d/ssl.disabled
/etc/httpd/conf.d/ssl.enabled
/etc/ld.so.conf.d/opt_soltra.conf
/opt/soltra/edge/var/repository/pki/twoway/01/index.txt
```

The /etc/yum/vars are marked as %config files in the edge2-yum-repo RPM:

```
(venv) [root@localhost makepkg]# rpm -qpcf /usr/share/edge/misc/pkgbuilds/edge2-yum-repo/edge2-yum-repo-2.9.0_rc.1-4.el6.x86_64.rpm
/etc/yum/vars/edge2-admin-email
/etc/yum/vars/edge2-up
/etc/yum/vars/edge2-yum-password
/etc/yum/vars/edge2-yum-username
```
