### PR TITLE
use the PKGBUILD license var for fpm --license param

### DIFF
--- a/makepkg.conf
+++ b/makepkg.conf
@@ -63,7 +63,7 @@ INTEGRITY_CHECK=(md5)
 #-- Log files: specify a fixed directory where all log files will be placed
 #LOGDEST=/home/makepkglogs
 #-- Packager: name/email of the person or organization building packages
-PACKAGER="Soltra Solutions, LLC"
+#PACKAGER="John Doe <john@doe.com>"
 
 #########################################################################
 # EXTENSION DEFAULTS
@@ -78,7 +78,7 @@ PKGEXT='.rpm'
 # makerpm only
 #########################################################################
 RPM_DIST="el6"
-RPM_VENDOR="Soltra Solutions, LLC"
-RPM_GROUP="edge2"
+#RPM_VENDOR="rqdq yo"
+
 
 # vim: set ft=sh ts=2 sw=2 et:

--- a/makepkg.conf
+++ b/makepkg.conf
@@ -63,7 +63,7 @@ INTEGRITY_CHECK=(md5)
 #-- Log files: specify a fixed directory where all log files will be placed
 #LOGDEST=/home/makepkglogs
 #-- Packager: name/email of the person or organization building packages
-#PACKAGER="John Doe <john@doe.com>"
+PACKAGER="Soltra Solutions, LLC"
 
 #########################################################################
 # EXTENSION DEFAULTS
@@ -78,7 +78,7 @@ PKGEXT='.rpm'
 # makerpm only
 #########################################################################
 RPM_DIST="el6"
-#RPM_VENDOR="rqdq yo"
-
+RPM_VENDOR="Soltra Solutions, LLC"
+RPM_GROUP="edge2"
 
 # vim: set ft=sh ts=2 sw=2 et:

--- a/makepkg.sh
+++ b/makepkg.sh
@@ -2248,6 +2248,12 @@ run_fpm() {
 	else
 		local vendor_param="--vendor \"$RPM_VENDOR\""
 	fi
+	if [[ "$LICENSE" = "" ]]; then
+		warning "RPM will have Soltra EULA License"
+		local license_param=''
+	else
+		local license_param="--license \"$LICENSE\""
+	fi
 	if [[ "$install" = "" ]]; then
 		local after_install_param=''
 	else
@@ -2263,6 +2269,7 @@ run_fpm() {
 	cmd="$cmd $description_param"
 	cmd="$cmd $url_param"
 	cmd="$cmd $vendor_param"
+	cmd="$cmd $license_param"
 	cmd="$cmd --name \"$nm\""
 	cmd="$cmd --version \"$pkgver\""
 	cmd="$cmd --iteration \"$pkgrel\""

--- a/makepkg.sh
+++ b/makepkg.sh
@@ -2248,12 +2248,6 @@ run_fpm() {
 	else
 		local vendor_param="--vendor \"$RPM_VENDOR\""
 	fi
-	if [[ "$LICENSE" = "" ]]; then
-		warning "RPM will have Soltra EULA License"
-		local license_param=''
-	else
-		local license_param="--license \"$LICENSE\""
-	fi
 	if [[ "$install" = "" ]]; then
 		local after_install_param=''
 	else
@@ -2263,13 +2257,14 @@ run_fpm() {
 	local cmd="fpm -s dir -t rpm --force -a $fpm_arch"
 	cmd="$cmd $rpm_dist_param"
 	cmd="$cmd --rpm-os linux"
+	# cmd="$cmd --debug-workspace"  # skips cleanup of /tmp and allows inspection of SPECFILE
 	cmd="$cmd --rpm-auto-add-directories"
 	cmd="$cmd --package \"$PKGDEST\"" # output path
 	cmd="$cmd $maintainer_param"
 	cmd="$cmd $description_param"
 	cmd="$cmd $url_param"
 	cmd="$cmd $vendor_param"
-	cmd="$cmd $license_param"
+	cmd="$cmd --license \"${license:-unknown}\""
 	cmd="$cmd --name \"$nm\""
 	cmd="$cmd --version \"$pkgver\""
 	cmd="$cmd --iteration \"$pkgrel\""
@@ -2281,6 +2276,7 @@ run_fpm() {
 	done
 	cmd="$cmd --rpm-use-file-permissions --rpm-user root --rpm-group root"
 	cmd="$cmd $@"
+        # echo $cmd  # for debugging
 	eval $cmd
 }
 


### PR DESCRIPTION
`makepkg` optionally takes a license var like: `license=('GPL')`

That var is now used in fpm as: `--license $license`

If no license is supplied, fpm is given: `--license='uknown'

```
(venv) [root@localhost makepkg]# rpm -qp --info /usr/share/edge/misc/pkgbuilds/edge2-yum-repo/edge2-yum-repo-2.9.0_rc.1-7.el6.x86_64.rpm
Name        : edge2-yum-repo               Relocations: / 
Version     : 2.9.0_rc.1                        Vendor: Soltra Solutions
Release     : 7.el6                         Build Date: Mon 26 Sep 2016 04:47:19 PM EDT
Install Date: (not installed)               Build Host: soltra.build.bot
Group       : default                       Source RPM: edge2-yum-repo-2.9.0_rc.1-7.el6.src.rpm
Size        : 1153                             License: http://soltra.com/eula-end-user-license-agreement
Signature   : (none)
Packager    : Soltra Solutions, LLC
URL         : https://soltra.com/
Summary     : Soltra Edge2 yum repo
Description :
Soltra Edge2 yum repo
```
